### PR TITLE
Patch docker conda install pip requirements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       context: .
       dockerfile: Dockerfile
     env_file: .env_docker
+    environment:
+      PIP_EXISTS_ACTION: w
     volumes:
       - .:/sd
       - ./outputs:/sd/outputs


### PR DESCRIPTION
Install getting stuck on user prompt because installation previously failed, and pip does not know what to do because some packages were cloned already. This defaults the pip exists action to wiping the already existing lib and re-downloading it
```
sd  | Obtaining GFPGAN from git+https://github.com/TencentARC/GFPGAN#egg=GFPGAN (from -r /sd/condaenv.h7qk_3wn.requirements.txt (line 25))
sd  | What to do?  (i)gnore, (w)ipe, (b)ackup 
sd  | failed
sd  | 
sd  | CondaEnvException: Pip failed
```
# Checklist:

- [ ] I have changed the base branch to `dev`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation